### PR TITLE
kb_54 fix Bootstraping a group.

### DIFF
--- a/lib/ctx.go
+++ b/lib/ctx.go
@@ -617,6 +617,10 @@ func (ctx *PfCtxS) IAmGroupAdmin() bool {
 		return false
 	}
 
+	if ctx.IsSysAdmin() {
+		return true
+	}
+
 	_, isadmin, _, err := ctx.sel_group.IsMember(ctx.user.GetUserName())
 	if err != nil {
 		return false


### PR DESCRIPTION
Before this change the user was a sysadmin but not a group admin.
Making a user an admin on a group requires admin status on that group.
Now a sysadmin can override that check.