### PR TITLE
Kb 55 Fix file listing depth check. 

### DIFF
--- a/lib/file.go
+++ b/lib/file.go
@@ -213,7 +213,7 @@ func File_ChildPagesList(ctx PfCtx, path string, offset int, max int) (paths []P
 
 		f.Fixup(ctx)
 
-		if pathOffset(f.Path,query_path) == 0 {
+		if PathOffset(f.Path, query_path) == 0 {
 			paths = append(paths, f)
 		}
 	}
@@ -221,13 +221,13 @@ func File_ChildPagesList(ctx PfCtx, path string, offset int, max int) (paths []P
 	return
 }
 
-func pathOffset(file_path string, dir_path string) (count int) {
+func PathOffset(file_path string, dir_path string) (count int) {
 	delta := strings.Replace(file_path, dir_path, "", 1)
 	tpl := len(delta) - 1
 	if delta[tpl] == '/' {
-		delta = this_path[0:tpl]
+		delta = delta[0:tpl]
 	}
-	return strings.count(delta, "/")
+	return strings.Count(delta, "/")
 }
 
 func (file *PfFile) Fetch(ctx PfCtx, path string, rev string) (err error) {

--- a/lib/file.go
+++ b/lib/file.go
@@ -156,6 +156,7 @@ func File_ChildPagesList(ctx PfCtx, path string, offset int, max int) (paths []P
 	paths = nil
 
 	mopts := File_GetModOpts(ctx)
+	query_path := path
 	path = URL_Append(mopts.Pathroot, path)
 
 	var rows *Rows
@@ -212,23 +213,21 @@ func File_ChildPagesList(ctx PfCtx, path string, offset int, max int) (paths []P
 
 		f.Fixup(ctx)
 
-		/* Don't show elements that are deeper than the current directory */
-		this_path := strings.Replace(f.Path, path, "", 1)
-
-		tpl := len(this_path) - 1
-		if this_path[tpl] == '/' {
-			this_path = this_path[0:tpl]
-		}
-		parts := strings.Split(this_path, "/")
-
-		partslen := len(parts)
-		if partslen == 1 || partslen == 2 {
-			/* Add the current file-dir */
+		if pathOffset(f.Path,query_path) == 0 {
 			paths = append(paths, f)
 		}
 	}
 
 	return
+}
+
+func pathOffset(file_path string, dir_path string) (count int) {
+	delta := strings.Replace(file_path, dir_path, "", 1)
+	tpl := len(delta) - 1
+	if delta[tpl] == '/' {
+		delta = this_path[0:tpl]
+	}
+	return strings.count(delta, "/")
 }
 
 func (file *PfFile) Fetch(ctx PfCtx, path string, rev string) (err error) {

--- a/lib/file_test.go
+++ b/lib/file_test.go
@@ -4,6 +4,32 @@ import (
 	"testing"
 )
 
+func TestpathOffset(t *testing.T){
+	tsts := []struct {
+		obj_path string
+		query_path string
+		value   int
+	}{
+		/* Positive tests */
+		{"/test.txt","/", 0},
+		{"/test/goo/bar/test.txt","/test/goo/",3}
+	}
+	for i := 0; i < len(tsts); i++ {
+		obj_path := tsts[i].obj_path
+		query_path := tsts[i].query_path
+		value := tsts[i].value
+		out := pathOffset(obj_path,query_path)
+		if out == value {
+			t.Logf("file_chk_path(%s) ok", path)
+		} else {
+			t.Errorf("file_chk_path(%s) failed", path)
+		}
+	}
+
+	return
+
+}
+
 func TestFileChkPath(t *testing.T) {
 	tsts := []struct {
 		path string

--- a/lib/file_test.go
+++ b/lib/file_test.go
@@ -4,15 +4,16 @@ import (
 	"testing"
 )
 
-func TestpathOffset(t *testing.T){
+func TestPathOffset(t *testing.T){
 	tsts := []struct {
 		obj_path string
 		query_path string
 		value   int
 	}{
 		/* Positive tests */
-		{"/test.txt","/", 0},
-		{"/test/goo/bar/test.txt","/test/goo/",3}
+		{"/test.txt", "/", 0},
+		{"/test/goo/bar/test.txt", "/test/goo/", 1},
+		{"/test/goo/bar/test.txt", "/", 3},
 	}
 	for i := 0; i < len(tsts); i++ {
 		obj_path := tsts[i].obj_path
@@ -20,9 +21,9 @@ func TestpathOffset(t *testing.T){
 		value := tsts[i].value
 		out := pathOffset(obj_path,query_path)
 		if out == value {
-			t.Logf("file_chk_path(%s) ok", path)
+			t.Logf("pathOffset(%s,%s) == %d ok", obj_path,query_path,value)
 		} else {
-			t.Errorf("file_chk_path(%s) failed", path)
+			t.Errorf("pathOffset(%s,%s) != %d failed, got %d", obj_path,query_path,value,out)
 		}
 	}
 

--- a/lib/group.go
+++ b/lib/group.go
@@ -911,7 +911,7 @@ func Group_FileMod(ctx PfCtx) {
 }
 
 func group_file(ctx PfCtx, args []string) (err error) {
-	gname := args[0]
+	grname := args[0]
 
 	err = ctx.SelectGroup(grname, PERM_GROUP_MEMBER)
 	if err != nil {

--- a/lib/group.go
+++ b/lib/group.go
@@ -911,6 +911,13 @@ func Group_FileMod(ctx PfCtx) {
 }
 
 func group_file(ctx PfCtx, args []string) (err error) {
+	gname := args[0]
+
+	err = ctx.SelectGroup(grname, PERM_GROUP_MEMBER)
+	if err != nil {
+		return
+	}
+
 	/* Module options */
 	Group_FileMod(ctx)
 

--- a/lib/group.go
+++ b/lib/group.go
@@ -921,7 +921,7 @@ func group_file(ctx PfCtx, args []string) (err error) {
 	/* Module options */
 	Group_FileMod(ctx)
 
-	return File_menu(ctx, args)
+	return File_menu(ctx, args[1:])
 }
 
 func Group_WikiMod(ctx PfCtx) {

--- a/lib/group.go
+++ b/lib/group.go
@@ -907,7 +907,7 @@ func Group_FileMod(ctx PfCtx) {
 	grpname := grp.GetGroupName()
 
 	/* Set the ModRoot options */
-	File_ModOpts(ctx, "group file", "/group/"+grpname, "/group/"+grpname+"/file")
+	File_ModOpts(ctx, "group file "+grpname, "/group/"+grpname, "/group/"+grpname+"/file")
 }
 
 func group_file(ctx PfCtx, args []string) (err error) {
@@ -947,7 +947,7 @@ func group_menu(ctx PfCtx, args []string) (err error) {
 		{"set", group_set, 0, -1, nil, PERM_USER, "Set properties of a group"},
 		{"get", group_get, 0, -1, nil, PERM_USER, "Get properties of a group"},
 		{"member", group_member, 0, -1, nil, PERM_USER, "Member commands"},
-		{"file", group_file, 0, -1, nil, PERM_USER, "File"},
+		{"file", group_file, 1, -1, []string{"group"}, PERM_USER, "File"},
 		{"wiki", group_wiki, 1, -1, []string{"group"}, PERM_USER, "Wiki"},
 	})
 


### PR DESCRIPTION
The prior code to check if a candidate directory item was in-path was broken. 
Simplified and corrected. 