### PR TITLE
Kb 63 Correct how the view of a directory is generated. 

### DIFF
--- a/lib/file.go
+++ b/lib/file.go
@@ -642,17 +642,25 @@ func file_add_entry(ctx PfCtx, ftype string, mimetype string, path string, descr
 		return
 	}
 
-	/* TODO walk the directory back and ensure all stages exist. */
-	dir_path = fp.Dir(path)
-	file_add_dir(ctx,[dir_path,"autocreated"])
-
 	/* All okay, commit the transaction */
 	err = DB.TxCommit(ctx)
+
+	/* walk the directory back and ensure all stages exist. */
+	path = strings.Replace(path, mopts.Pathroot, "", 1)
+	path_len := len(path)
+	if path[path_len-1] == '/' {
+		path = path[:path_len-1]
+	}
+	dir_path := fp.Dir(path) + "/"
+	if len(dir_path) > 1 {
+		file_add_dir(ctx,[]string{dir_path, "autocreated"})
+	}
 
 	return
 }
 
 func file_add_dir(ctx PfCtx, args []string) (err error) {
+	var f PfFile
 	path := args[0]
 	description := args[1]
 
@@ -681,10 +689,6 @@ func file_add_dir(ctx PfCtx, args []string) (err error) {
 	if err == nil {
 		ctx.OutLn("Directory added successfully")
 	}
-
-	/* TODO walk the directory back and ensure all stages exist. */
-	dir_path = fp.Dir(path)
-	file_add_dir(ctx,[dir_path,"autocreated"])
 
 	return
 }

--- a/lib/file.go
+++ b/lib/file.go
@@ -642,6 +642,10 @@ func file_add_entry(ctx PfCtx, ftype string, mimetype string, path string, descr
 		return
 	}
 
+	/* TODO walk the directory back and ensure all stages exist. */
+	dir_path = fp.Dir(path)
+	file_add_dir(ctx,[dir_path,"autocreated"])
+
 	/* All okay, commit the transaction */
 	err = DB.TxCommit(ctx)
 
@@ -657,6 +661,16 @@ func file_add_dir(ctx PfCtx, args []string) (err error) {
 		return
 	}
 
+	err = f.Fetch(ctx, path, "")
+	if err == nil {
+		err = ErrFilePathExists
+		return
+	} else if err != ErrNoRows {
+		ctx.Errf("Expected ErrNoRows for %q: but %s", path, err.Error())
+		err = errors.New("Error while checking for existing entry")
+		return
+	}
+
 	if !File_path_is_dir(path) {
 		err = errors.New("Path has to start and end with a slash (/) to be a directory")
 		return
@@ -667,6 +681,10 @@ func file_add_dir(ctx PfCtx, args []string) (err error) {
 	if err == nil {
 		ctx.OutLn("Directory added successfully")
 	}
+
+	/* TODO walk the directory back and ensure all stages exist. */
+	dir_path = fp.Dir(path)
+	file_add_dir(ctx,[dir_path,"autocreated"])
 
 	return
 }


### PR DESCRIPTION
-file_add_dir was not checking if the file exist. 
-file_add_entity now tries to create all of the directories in the chain from root. 