### PR TITLE
Kb 74 Change LN in pitchfork Makefile to cp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ deps:
 	@echo "- Fetching EpicEditor..."
 	@git clone https://github.com/OscarGodson/EpicEditor.git ext/epiceditor/
 	@rm -f share/webroot/js/epiceditor.min.js
-	@cp ../../../ext/epiceditor/epiceditor/js/epiceditor.min.js share/webroot/js/
+	@cp ext/epiceditor/epiceditor/js/epiceditor.min.js share/webroot/js/
 	@rm -f share/webroot/css/epiceditor/themes
 	@mkdir -p share/webroot/css/epiceditor/
-	@cp ../../../../ext/epiceditor/epiceditor/themes share/webroot/css/epiceditor/
+	@cp -r ext/epiceditor/epiceditor/themes share/webroot/css/epiceditor/
 	@echo "Fetching Pitchfork Dependencies... done"
 
 check: deps

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ deps:
 	@echo "- Fetching EpicEditor..."
 	@git clone https://github.com/OscarGodson/EpicEditor.git ext/epiceditor/
 	@rm -f share/webroot/js/epiceditor.min.js
-	@ln -s ../../../ext/epiceditor/epiceditor/js/epiceditor.min.js share/webroot/js/
+	@cp ../../../ext/epiceditor/epiceditor/js/epiceditor.min.js share/webroot/js/
 	@rm -f share/webroot/css/epiceditor/themes
 	@mkdir -p share/webroot/css/epiceditor/
-	@ln -s ../../../../ext/epiceditor/epiceditor/themes share/webroot/css/epiceditor/
+	@cp ../../../../ext/epiceditor/epiceditor/themes share/webroot/css/epiceditor/
 	@echo "Fetching Pitchfork Dependencies... done"
 
 check: deps


### PR DESCRIPTION
The paths to epiceditor were based on one install system, not a clean package. 