### PR TITLE
kb_98 Adding approve path

### DIFF
--- a/ui/group.go
+++ b/ui/group.go
@@ -179,6 +179,7 @@ func h_group_cmd(cui PfUI) {
 	case "unblock":
 	case "promote":
 	case "demote":
+	case "approve":
 	default:
 		cui.Errf("Unknown Group command: %q", cmd)
 		return


### PR DESCRIPTION
Simple fix, add approve to the cmd list. (works in testing). 