### PR TITLE
Adding additional Hints as suggested by trident issue_39

### DIFF
--- a/lib/system.go
+++ b/lib/system.go
@@ -22,12 +22,12 @@ type PfSys struct {
 	EmailDomain      string      `label:"Email Domain" pfset:"sysadmin" pfcol:"email_domain" hint:"The domain where emails are sourced from"`
 	PublicURL        string      `label:"Public URL" pfset:"sysadmin" pfcol:"url_public" hint:"The full URL where the system is exposed to the public, used for redirects and OAuth2 (Example: https://example.net)"`
 	PeopleDomain     string      `label:"People Domain" pfset:"sysadmin" pfcol:"people_domain" hint:"Domain used for people's email addresses and identifiers (Example: people.example.net)"`
-	CLIEnabled       bool        `label:"CLI Enabled" pfset:"sysadmin" pfcol:"cli_enabled" hint:"Enable the Web CLI (/cli/)"`
-	APIEnabled       bool        `label:"API Enabled" pfset:"sysadmin" pfcol:"api_enabled" hint:"Enable the API URL (/api/) thus allowing external tools to access the details provided they have authenticated"`
-	OAuthEnabled     bool        `label:"OAuth/OpenID Enabled" pfset:"sysadmin" pfcol:"oauth_enabled" hint:"Enable OAuth 2.0 and OpenID Connect support (/oauth2/ + /.wellknown/webfinger)"`
-	NoIndex          bool        `label:"No Web Indexing" pfset:"sysadmin" pfcol:"no_index" hint:"Disallow Web crawlers/robots from indexing and following links"`
+	CLIEnabled       bool        `label:"CLI Enabled" pfset:"sysadmin" pfcol:"cli_enabled" hint:"Show the Web Command Line Interface to Regular users. Default: Off (Always available for Administrators)."`
+	APIEnabled       bool        `label:"API Enabled" pfset:"sysadmin" pfcol:"api_enabled" hint:"Enable the API URL (/api/) thus allowing external tools to access the details provided they have authenticated. Default: On"`
+	OAuthEnabled     bool        `label:"OAuth/OpenID Enabled" pfset:"sysadmin" pfcol:"oauth_enabled" hint:"Enable OAuth 2.0 and OpenID Connect support (/oauth2/ + /.wellknown/webfinger). Default: On"`
+	NoIndex          bool        `label:"No Web Indexing" pfset:"sysadmin" pfcol:"no_index" hint:"Disallow Web crawlers/robots from indexing and following links. Default: On"`
 	EmailSig         string      `label:"Email Signature" pftype:"text" pfset:"sysadmin" pfcol:"email_sig" hint:"Signature appended to mailinglist messages"`
-	Require2FA       bool        `label:"Require 2FA" pfset:"sysadmin" hint:"Require Two Factor Authentication (2FA) for every Login"`
+	Require2FA       bool        `label:"Require 2FA" pfset:"sysadmin" hint:"Require Two Factor Authentication (2FA) for every Login, If disabled users may still configure 2FA for their account."`
 	PW_comment       string      `pfsection:"Password Rules" label:"Setting password rules is not recommended. Please use XKCD style passwords instead." pftype:"note"`
 	PW_Enforce       bool        `pfsection:"Password Rules" label:"Enforce Rules" hint:"When enabled the rules below are enforced on new passwords"`
 	PW_Length        int         `pfsection:"Password Rules" label:"Minimal Password Length (suggested: 12, min: 8)" min:"8"`

--- a/lib/user_email.go
+++ b/lib/user_email.go
@@ -64,8 +64,7 @@ func (uem *PfUserEmail) FetchGroups(ctx PfCtx) (err error) {
 	}
 
 	for _, g := range groups {
-		if uem.Email == g.GetEmail() ||
-			(!ctx.IsSysAdmin() && !g.GetGroupCanSee()) {
+		if uem.Email == g.GetEmail() && g.GetGroupCanSee() {
 			uem.Groups = append(uem.Groups, g)
 		}
 	}

--- a/share/templates/user/email/edit.tmpl
+++ b/share/templates/user/email/edit.tmpl
@@ -13,29 +13,68 @@ Verification in Process
 Unverified
 {{ end }}{{/* .Email.VerifyCode */}}
 {{ end }}{{/* .Email.Verified */}}</td>
+<tr><th>Groups</th><td>
+<ul>
+{{ range $i, $grp := .Email.Groups }}
+<li>{{ $grp.GroupName }}
+{{ end }}
+</ul>
+</td>
 <tr><th>Actions</th><td>
 
 {{ if .Email.Verified }}
-{{ else }}
-{{ if .Email.VerifyCode }}
-{{ pfform .UI .Confirm .Confirm true }}
-{{ pfform .UI .Resend .Resend true }}
-{{ else }}
-{{ pfform .UI .Verify .Verify true }}
-{{ end }}{{/* .Email.VerifyCode */}}
-
 {{ if .IsRecover }}
 {{ else }}
-{{ if .Email.Verified }}
-{{ pfform .UI .SetRecover .SetRecover true }}
-{{ end }}{{/* .Email.Verified */}}
+{{ csrf_form $.UI "" }}
+	<fieldset>
+		<ul>
+			<li>
+				<input type="hidden" name="action" value="setrecover" />
+				<input id="button" type="submit" name="button" value="Make Recover Email" />
+			</li>
+		</ul>
+	</fieldset>
+</form>
 {{ end }}{{/* .IsRecover */}}
+{{ else }} {{/* .Email.Verified */}}
+{{ if .Email.VerifyCode }}
+{{ pfform .UI .Confirm .Confirm true }}
+{{ csrf_form $.UI "" }}
+	<fieldset>
+		<ul>
+			<li>
+				<input type="hidden" name="action" value="resend" />
+				<input id="button" type="submit" name="button" value="Resend Verify" />
+			</li>
+		</ul>
+	</fieldset>
+</form>
+{{ else }} {{/* .Email.VerifyCode */}}
+{{ csrf_form $.UI "" }}
+	<fieldset>
+		<ul>
+			<li>
+				<input type="hidden" name="action" value="verify" />
+				<input id="button" type="submit" name="button" value="Verify" />
+			</li>
+		</ul>
+	</fieldset>
+</form>
+{{ end }}{{/* .Email.VerifyCode */}}
+{{ end }}{{/* .Email.Verified */}}
 
 {{ if .CanDelete }}
-{{ pfform .UI .Remove .Remove true }}
+{{ csrf_form $.UI "" }}
+	<fieldset>
+		<ul>
+			<li>
+				<input type="hidden" name="action" value="remove" />
+				<input id="button" type="submit" name="button" value="Reomve Email" />
+			</li>
+		</ul>
+	</fieldset>
+</form>
 {{ end }}{{/* .CanDelete */}}
-
-{{ end }}{{/* .Email.Verified */}}
 
 </td></tr>
 <tr><th>PGP Key</th><td>

--- a/ui/user_email.go
+++ b/ui/user_email.go
@@ -2,6 +2,7 @@ package pitchforkui
 
 import (
 	"strings"
+
 	"trident.li/keyval"
 	pf "trident.li/pitchfork/lib"
 )
@@ -165,8 +166,12 @@ func h_user_email_set_recover(cui PfUI) (err error) {
 func h_user_email_verify(cui PfUI) (err error) {
 	email := cui.SelectedEmail()
 
-	/* Generate and send a Verification Code */
-	err = email.SendVerificationCode(cui)
+	cmd := "user email confirm_begin"
+	arg := []string{email.Email}
+
+	_, err = cui.HandleCmd(cmd, arg)
+	return
+
 	return
 }
 
@@ -215,29 +220,10 @@ func h_user_email_edit(cui PfUI) {
 		H_errmsg(cui, err)
 		return
 	}
-
-	type opt_remove struct {
-		Action string `label:"remove" pftype:"hidden"`
-		Button string `label:"Remove" pftype:"submit"`
-		Error  string /* Used by pfform() */
-	}
-
-	type opt_setrecover struct {
-		Action string `label:"setrecover" pftype:"hidden"`
-		Button string `label:"Select as Recovery Email" pftype:"submit"`
-		Error  string /* Used by pfform() */
-	}
-
-	type opt_resend struct {
-		Action string `label:"resend" pftype:"hidden"`
-		Button string `label:"Resend" pftype:"submit"`
-		Error  string /* Used by pfform() */
-	}
-
-	type opt_verify struct {
-		Action string `label:"verify" pftype:"hidden"`
-		Button string `label:"Verify" pftype:"submit"`
-		Error  string /* Used by pfform() */
+	err = email.FetchGroups(cui)
+	if err != nil {
+		H_errmsg(cui, err)
+		return
 	}
 
 	type opt_confirm struct {
@@ -254,10 +240,6 @@ func h_user_email_edit(cui PfUI) {
 		Error   string /* Used by pfform() */
 	}
 
-	o_remove := opt_remove{}
-	o_setrecover := opt_setrecover{}
-	o_resend := opt_resend{}
-	o_verify := opt_verify{}
 	o_confirm := opt_confirm{}
 	o_uploadkey := opt_uploadkey{}
 
@@ -279,33 +261,19 @@ func h_user_email_edit(cui PfUI) {
 			if err == nil {
 				cui.SetRedirect("/user/"+user.GetUserName()+"/email/", StatusSeeOther)
 				return
-			} else {
-				o_remove.Error = err.Error()
 			}
 			break
 
 		case "setrecover":
 			err = h_user_email_set_recover(cui)
-
-			if err != nil {
-				o_setrecover.Error = err.Error()
-			}
 			break
 
 		case "resend":
 			err = h_user_email_verify(cui)
-
-			if err != nil {
-				o_resend.Error = err.Error()
-			}
 			break
 
 		case "verify":
 			err = h_user_email_verify(cui)
-
-			if err != nil {
-				o_verify.Error = err.Error()
-			}
 			break
 
 		case "confirm":
@@ -355,22 +323,18 @@ func h_user_email_edit(cui PfUI) {
 	/* Output the package */
 	type Page struct {
 		*PfPage
-		Message    string
-		Error      string
-		User       pf.PfUser
-		Email      pf.PfUserEmail
-		IsEdit     bool
-		CanDelete  bool
-		IsRecover  bool
-		Remove     opt_remove
-		SetRecover opt_setrecover
-		Resend     opt_resend
-		Verify     opt_verify
-		Confirm    opt_confirm
-		UploadKey  opt_uploadkey
+		Message   string
+		Error     string
+		User      pf.PfUser
+		Email     pf.PfUserEmail
+		IsEdit    bool
+		CanDelete bool
+		IsRecover bool
+		Confirm   opt_confirm
+		UploadKey opt_uploadkey
 	}
 
-	p := Page{cui.Page_def(), msg, errmsg, user, email, isedit, candelete, isrecover, o_remove, o_setrecover, o_resend, o_verify, o_confirm, o_uploadkey}
+	p := Page{cui.Page_def(), msg, errmsg, user, email, isedit, candelete, isrecover, o_confirm, o_uploadkey}
 	cui.Page_show("user/email/edit.tmpl", p)
 }
 

--- a/ui/user_email.go
+++ b/ui/user_email.go
@@ -171,8 +171,6 @@ func h_user_email_verify(cui PfUI) (err error) {
 
 	_, err = cui.HandleCmd(cmd, arg)
 	return
-
-	return
 }
 
 func h_user_email_confirmform(cui PfUI) (err error) {


### PR DESCRIPTION
From stewrg:  https://github.com/tridentli/trident/issues/39

in /system/settings:

I suggest adding the following explanatory text on roll-over help popups

CLI Enabled : “Show the Web Command Line Interface to Regular users. Default: Off (Always available for Administrators).” 

API Enabled : add “Default: On” 

OAuth/OpenID Enabled : add “Default: On” 

No Web Indexing : add “Default: On” 

Require 2FA : add “If set to “off” individual users can still choose to as option. Default Off”