### PR TITLE
Pf issue #55 move e-mail validate into pf.user.Create()

### DIFF
--- a/lib/user.go
+++ b/lib/user.go
@@ -959,8 +959,8 @@ func (user *PfUserS) Create(ctx PfCtx, username string, email string, bio_info s
 	}
 
 	q = "INSERT INTO member_email " +
-		"(member, email) " +
-		"VALUES($1, $2)"
+		"(member, email, verified) " +
+		"VALUES($1, $2, 't')"
 
 	err = DB.Exec(ctx,
 		"Added email address $2 to user $1",


### PR DESCRIPTION
Prior to this change the user e-mail was verified in the ui/user_nominate function. 
This requires sysadmin access, which is too restrictive. 
Changed the pf/lib/user.Create() to include verified when creating a new user. 