### PR TITLE
Make username length a config variable

### DIFF
--- a/lib/cfg.go
+++ b/lib/cfg.go
@@ -48,6 +48,8 @@ type PfConfig struct {
 	TimeFormat      string       `json:"timeformat"`
 	DateFormat      string       `json:"dateformat"`
 	PW_WeakDicts    []string     `json:"pw_weakdicts"`
+	CFG_UserMinLen  string       `json:"username_min_length"`
+	CFG_UserExample string       `json:"username_example"`
 }
 
 /* SMTP_SSL = ignore | require */

--- a/ui/form.go
+++ b/ui/form.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+
 	"trident.li/keyval"
 	pf "trident.li/pitchfork/lib"
 )
@@ -160,8 +161,17 @@ func pfform_string(kvs keyval.KeyVals, val, idpfx, fname, ttype, opts, min, max 
 	if min != "" || max != "" {
 		if min == "" {
 			min = "0"
+		} else if strings.HasPrefix(min, "CFG_") {
+			r := reflect.ValueOf(pf.Config)
+			f := reflect.Indirect(r).FieldByName(min)
+			min = string(f.String())
 		}
-
+		if max == "" {
+		} else if strings.HasPrefix(max, "CFG_") {
+			r := reflect.ValueOf(pf.Config)
+			f := reflect.Indirect(r).FieldByName(max)
+			max = string(f.String())
+		}
 		t += " pattern=\".{" + min + "," + max + "}\""
 	}
 
@@ -507,6 +517,12 @@ func pfformA(cui PfUI, section *string, idpfx string, objtrail []interface{}, ob
 		}
 
 		if placeholder != "" {
+			if strings.HasPrefix(placeholder, "CFG_") {
+				r := reflect.ValueOf(pf.Config)
+				f := reflect.Indirect(r).FieldByName(placeholder)
+				placeholder = string(f.String())
+			}
+
 			opts += " placeholder=\"" + pf.HE(placeholder) + "\""
 		}
 

--- a/ui/login.go
+++ b/ui/login.go
@@ -1,7 +1,7 @@
 package pitchforkui
 
 type login struct {
-	Username  string `label:"Username" hint:"Your username" min:"3" pfreq:"yes" placeholder:"user@example.com"`
+	Username  string `label:"Username" hint:"Your username" min:"CFG_UserMinLen" pfreq:"yes" placeholder:"CFG_UserExample"`
 	Password  string `label:"Password" hint:"Your password" min:"6" pfreq:"yes" pftype:"password" placeholder:"4.very/difficult_p4ssw0rd"`
 	TwoFactor string `label:"Two Factor Code" hint:"Two Factor Token (if configured)" placeholder:"314159"`
 	Comeback  string `label:"Comeback" pftype:"hidden"`


### PR DESCRIPTION
Fixes #65 

- Add config variables for username length and placeholder. 
- Allow for config-based pf-form properties. 