### PR TITLE
Text fixups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ deps:
 	@mkdir -p share/webroot/css/epiceditor/
 	@cp -r ext/epiceditor/epiceditor/themes share/webroot/css/epiceditor/
 	@echo "Fetching Pitchfork Dependencies... done"
+	@echo "Fetching go dependencies..."
+	@go get -v -d ./...
+	@echo "...done"
 
 check: deps
 	@echo "- Running 'go vet'"

--- a/README.md
+++ b/README.md
@@ -60,36 +60,3 @@ and negative checks may be performed.
 Passing a set Username in the test causes a cookie to be created for that
 user and it automatically looks as if that user has logged into the system.
 
-### Prerequisite GoLang Libraries
-
-There are several prerequisite libraries which must be installed prior to
-testing pitchfork, or building it. The list is:
-
-```
-github.com/aryann/difflib
-github.com/asaskevich/govalidator
-github.com/dgrijalva/jwt-go
-github.com/disintegration/imaging
-github.com/lib/pq
-github.com/microcosm-cc/bluemonday
-github.com/mssola/user_agent
-github.com/nicksnyder/go-i18n/i18n
-github.com/pborman/uuid
-github.com/russross/blackfriday
-github.com/shurcooL/highlight_go
-github.com/sourcegraph/syntaxhighlight
-golang.org/x/crypto/openpgp
-golang.org/x/crypto/openpgp/armor
-golang.org/x/crypto/openpgp/packet
-golang.org/x/crypto/openpgp/s2k
-golang.org/x/crypto/ssh/terminal
-trident.li/pitchfork/cmd/cli/cmd
-trident.li/pitchfork/cmd/cli/cmd
-trident.li/pitchfork/lib
-trident.li/pitchfork/ui
-trident.li/go/osutil-crypt
-trident.li/go/osutil-crypt/common
-trident.li/keyval
-trident.li/pitchfork/lib/pgp
-trident.li/go/rsc/qr
-```

--- a/README.md
+++ b/README.md
@@ -5,20 +5,20 @@ and other tools build upon this framework.
 
 ## Testing
 
-We include tests using the go [testing](https://golang.org/pkg/testing/)
+Tests are included using the go [testing](https://golang.org/pkg/testing/)
 framework.
 
 ### Running Tests
 
-Running tests requires that two environment variables are set:
+Running tests requires two environment variables to be are set:
 ```
 export PITCHFORK_TOOLNAME=trident
-export PITCHFORK_CONFROOT=/Users/jeroen/git/trident/tconf/
+export PITCHFORK_CONFROOT=/Users/${USER}/git/trident/tconf/
 ```
-These specify the name of the tool (and thus the name of the configfile)
-and the directory where the config file and related files are loaded from.
+These specify the name of the tool which, by extension, names the configuration
+file and the directory where the config file and related files are loaded from.
 
-One can then run the tests with:
+Tests can be executed with:
 ```
 make tests
 ```
@@ -33,7 +33,7 @@ go test trident.li/pitchfork/lib -v
 go test trident.li/pitchfork/ui -v
 ```
 
-One can also run tests individually by specifying a filter, eg:
+Tests may also be individually executed by specifying a filter, eg:
 ```
 go test trident.li/pitchfork/lib -v -run IPtrk
 ```
@@ -42,23 +42,23 @@ which would run only the iptrk related tests.
 The argument to ```-run``` is a regexp, ```AB[CD]``` would for instance
 match functions named ```Test_ABC``` + ```Test_ABD```.
 
-See also the top of the *._test.go files for the simple cut&paste variants.
+See also the top of the *._test.go files for simple cut&paste variants.
 
 ### CLI Tests
 
 Either make mini tests for the exact functions.
-Or Call pf.Cmd() passing the various that need to be done.
+Or Call pf.Cmd() passing the various operations that need to be done.
 Error or return body can then be checked.
 
 ### UI Tests
 
 Pitchfork's URLTest module (```ui/urltest/```) contains the URL_Test()
-function that accepts a URLTest structure that allows passing in various
-variables that act as the request or as the response checks. One can do
-positive and negative checks with it.
+function that accepts a URLTest structure which allows passing in 
+variables that act as the request or as the response checks, positive
+and negative checks may be performed.
 
 Passing a set Username in the test causes a cookie to be created for that
-user and thus it automatically looks like one is logged in as that user.
+user and it automatically looks as if that user has logged into the system.
 
 ### Prerequisite GoLang Libraries
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ framework.
 Running tests requires two environment variables to be are set:
 ```
 export PITCHFORK_TOOLNAME=trident
-export PITCHFORK_CONFROOT=/Users/${USER}/git/trident/tconf/
+export PITCHFORK_CONFROOT=/${HOME}/repositories/path/trident/tconf/
 ```
 These specify the name of the tool which, by extension, names the configuration
 file and the directory where the config file and related files are loaded from.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ framework.
 Running tests requires two environment variables to be are set:
 ```
 export PITCHFORK_TOOLNAME=trident
-export PITCHFORK_CONFROOT=/${HOME}/repositories/path/trident/tconf/
+export PITCHFORK_CONFROOT=${HOME}/repositories/path/trident/tconf/
 ```
 These specify the name of the tool which, by extension, names the configuration
 file and the directory where the config file and related files are loaded from.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Pitchfork
 
-Pitchfork is a framework forming the basis for [Trident](https://trident.li) and other tools build upon this framework.
+Pitchfork is a framework forming the basis for [Trident](https://trident.li)
+and other tools build upon this framework.
 
 ## Testing
 
-We include tests using the go [testing](https://golang.org/pkg/testing/) framework.
+We include tests using the go [testing](https://golang.org/pkg/testing/)
+framework.
 
 ### Running Tests
 
@@ -37,8 +39,8 @@ go test trident.li/pitchfork/lib -v -run IPtrk
 ```
 which would run only the iptrk related tests.
 
-The argument to ```-run``` is a regexp, ```AB[CD]``` would for instance match functions named
-```Test_ABC``` + ```Test_ABD```.
+The argument to ```-run``` is a regexp, ```AB[CD]``` would for instance
+match functions named ```Test_ABC``` + ```Test_ABD```.
 
 See also the top of the *._test.go files for the simple cut&paste variants.
 
@@ -50,9 +52,44 @@ Error or return body can then be checked.
 
 ### UI Tests
 
-Pitchfork's URLTest module (```ui/urltest/```) contains the URL_Test() function that
-accepts a URLTest structure that allows passing in various variables that act as the
-request or as the response checks. One can do positive and negative checks with it.
+Pitchfork's URLTest module (```ui/urltest/```) contains the URL_Test()
+function that accepts a URLTest structure that allows passing in various
+variables that act as the request or as the response checks. One can do
+positive and negative checks with it.
 
-Passing a set Username in the test causes a cookie to be created for that user and thus
-it automatically looks like one is logged in as that user.
+Passing a set Username in the test causes a cookie to be created for that
+user and thus it automatically looks like one is logged in as that user.
+
+### Prerequisite GoLang Libraries
+
+There are several prerequisite libraries which must be installed prior to
+testing pitchfork, or building it. The list is:
+
+```
+github.com/aryann/difflib
+github.com/asaskevich/govalidator
+github.com/dgrijalva/jwt-go
+github.com/disintegration/imaging
+github.com/lib/pq
+github.com/microcosm-cc/bluemonday
+github.com/mssola/user_agent
+github.com/nicksnyder/go-i18n/i18n
+github.com/pborman/uuid
+github.com/russross/blackfriday
+github.com/shurcooL/highlight_go
+github.com/sourcegraph/syntaxhighlight
+golang.org/x/crypto/openpgp
+golang.org/x/crypto/openpgp/armor
+golang.org/x/crypto/openpgp/packet
+golang.org/x/crypto/openpgp/s2k
+golang.org/x/crypto/ssh/terminal
+trident.li/pitchfork/cmd/cli/cmd
+trident.li/pitchfork/cmd/cli/cmd
+trident.li/pitchfork/lib
+trident.li/pitchfork/ui
+trident.li/go/osutil-crypt
+trident.li/go/osutil-crypt/common
+trident.li/keyval
+trident.li/pitchfork/lib/pgp
+trident.li/go/rsc/qr
+```

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ See also the top of the *._test.go files for simple cut&paste variants.
 ### CLI Tests
 
 Either make mini tests for the exact functions.
-Or Call pf.Cmd() passing the various operations that need to be done.
+Or call pf.Cmd() passing the various operations that need to be done.
 Error or return body can then be checked.
 
 ### UI Tests

--- a/lib/file_test.go
+++ b/lib/file_test.go
@@ -19,11 +19,11 @@ func TestPathOffset(t *testing.T) {
 		obj_path := tsts[i].obj_path
 		query_path := tsts[i].query_path
 		value := tsts[i].value
-		out := pathOffset(obj_path, query_path)
+		out := PathOffset(obj_path, query_path)
 		if out == value {
-			t.Logf("pathOffset(%s,%s) == %d ok", obj_path, query_path, value)
+			t.Logf("PathOffset(%s,%s) == %d ok", obj_path, query_path, value)
 		} else {
-			t.Errorf("pathOffset(%s,%s) != %d failed, got %d", obj_path, query_path, value, out)
+			t.Errorf("PathOffset(%s,%s) != %d failed, got %d", obj_path, query_path, value, out)
 		}
 	}
 

--- a/share/templates/user/email/list.tmpl
+++ b/share/templates/user/email/list.tmpl
@@ -57,7 +57,7 @@
 	</tbody>
 	</table>
 
-	<h2>Add a new Email Address</h2>
+	<h2>Add a new email address</h2>
 
 	{{ pfform .UI .Add .Add true }}
 

--- a/ui/form.go
+++ b/ui/form.go
@@ -588,12 +588,12 @@ func pfformA(cui PfUI, section *string, idpfx string, objtrail []interface{}, ob
 
 		t += pfform_label(idpfx, fname, tlabel, ttype)
 
-		ftype := f.Type.Kind()
+		pftype := f.Type.Kind()
 
-		switch ftype {
+		switch pftype {
 		case reflect.String:
 			switch ttype {
-			case "string", "tel", "email", "submit", "password", "text":
+			case "email", "password", "string", "submit", "tel", "text":
 				val := label
 
 				if ttype != "submit" {

--- a/ui/form.go
+++ b/ui/form.go
@@ -886,7 +886,7 @@ func pfformA(cui PfUI, section *string, idpfx string, objtrail []interface{}, ob
 			break
 
 		default:
-			return TFErr(cui, "Field '"+fname+"' is an unknown type "+ftype.String()+": "+pf.StructNameT(f.Type))
+			return TFErr(cui, "Field '"+fname+"' is an unknown type "+pftype.String()+": "+pf.StructNameT(f.Type))
 		}
 
 		if t != "" {

--- a/ui/main_test.go
+++ b/ui/main_test.go
@@ -3,6 +3,7 @@ package pitchforkui
 import (
 	"os"
 	"testing"
+
 	pf "trident.li/pitchfork/lib"
 	pftst "trident.li/pitchfork/lib/test"
 )

--- a/ui/root_test.go
+++ b/ui/root_test.go
@@ -1,9 +1,9 @@
-package pitchforkui_test
+package pitchforkui
 
 import (
 	"net/http"
 	"testing"
-	pu "trident.li/pitchfork/ui"
+
 	urltest "trident.li/pitchfork/ui/urltest"
 )
 
@@ -22,7 +22,7 @@ func TestUI_Main_Misc(t *testing.T) {
 	}
 
 	/* Our Root */
-	root := pu.NewPfRootUI(pu.TestingUI)
+	root := NewPfRootUI(TestingUI)
 
 	for _, u := range tests {
 		urltest.Test_URL(t, root.H_root, u)


### PR DESCRIPTION
Ben, this is just (mostly) documentation fixes... and a variable-rename to follow examples in the same source file.

I need a pointer (which I can add to my local branch and send a pull request for) to an example/useful trident config. I haven't seen one in the repository, but also maybe my grep-r isn't good enough.

I'm looking for what content would go in the directory(s) named in the testing README:

------------------- snip ------------------------
### Running Tests

Running tests requires two environment variables to be are set:
```
export PITCHFORK_TOOLNAME=trident
export PITCHFORK_CONFROOT=/Users/${USER}/git/trident/tconf/
```
These specify the name of the tool which, by extension, names the configuration
file and the directory where the config file and related files are loaded from.

------------------ snip ---------------------------

if you point me to an example I can work out making it work for me, and updating docs/repository with relevant bits.