### PR TITLE
Fix PGP Key Download Link on Edit Email Page

### DIFF
--- a/share/templates/user/email/edit.tmpl
+++ b/share/templates/user/email/edit.tmpl
@@ -82,7 +82,7 @@ Unverified
 <table>
 	<tr><th>Key ID:</th><td>{{ .Email.PgpKeyID }}</td></tr>
 	<tr><th>Expires:</th><td> {{ fmt_time .Email.PgpKeyExpire }}</td></tr>
-	<tr><th>Download:</th><td><a href="{{ .Email.Email }}/download">{{ .Email.PgpKeyID }}.asc</a></td></tr>
+	<tr><th>Download:</th><td><a href="download">{{ .Email.PgpKeyID }}.asc</a></td></tr>
 </table>
 {{ else }}
 Not defined


### PR DESCRIPTION
The PGP download link on the edit email page was broken because it added a duplicate email address to the existing path which already had the user email address. #144 