### PR TITLE
For tick/1961 - add ARF files as possible uploads to the wiki.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -9,6 +9,7 @@ pitchfork (1.9.5) stable; urgency=medium
   * (T93) Add a note in UI and email about the characters used in the recovery token
   * (PF Merge 163) Typo Fix by wesdawg
   * (PF Merge 160) Fix PGP download link by wesdawg
+  * Support ARF files.
 
  -- Ben April <bapril@ops-trust.net>  Sun, 24 Sep 2017 00:46:15 -0400
 

--- a/lib/file.go
+++ b/lib/file.go
@@ -320,6 +320,7 @@ func file_mimetype(path string) (mt string, err error) {
 
 	/* Quick lookup of our own to guarantee that these types are supported */
 	types := map[string]string{
+		"arf":  "application/octet-stream",
 		"doc":  "application/msword",
 		"docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
 		"html": "text/html",


### PR DESCRIPTION
Add the ARF file type (webex recordings) to possible wiki file uploads.