### PR TITLE
Fix the file_test.go usage of pathOffset

### DIFF
--- a/lib/file_test.go
+++ b/lib/file_test.go
@@ -20,7 +20,7 @@ func TestPathOffset(t *testing.T) {
 		obj_path := tsts[i].obj_path
 		query_path := tsts[i].query_path
 		value := tsts[i].value
-		out := pathOffset(obj_path, query_path)
+		out := PathOffset(obj_path, query_path)
 		if out == value {
 			t.Logf("pathOffset(%s,%s) == %d ok", obj_path, query_path, value)
 		} else {


### PR DESCRIPTION
This should really be: PathOffset
which is the name of the function in file.go, otherwise:
b (master)$ go test
 _/home/morrowc/scripts/git/trident/ext/_gopath/src/trident.li/pitchfork/lib
./file_test.go:22: undefined: pathOffset